### PR TITLE
composer.json support php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "TYPO3 PhotoSwipe-Plugin for native image-enlargement",
   "license": "GPL-2.0-or-later",
   "require": {
-    "php": "^7.4",
+    "php": "^7.4 || ^8.0",
     "typo3/cms-backend": "^9.5  || ^10.4 || ^11.5",
     "typo3/cms-core": "^9.5 || ^10.4 || ^11.5"
   },


### PR DESCRIPTION
hi !

Installations via composer on a php8 server fails when the `--ignore-platform-reqs` param is not specified.
This PR is to require php8 to the requirements.

Thank you