### PR TITLE
Drop references to TYPO3_MODE constant

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,4 +1,4 @@
 <?php
-defined('TYPO3') || defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('photoswipe', 'Configuration/TypoScript', 'PhotoSwipe');

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3') || defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 $ttContentColumns = [
     'imagelazy64' => [

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,7 +1,6 @@
 <?php
-defined('TYPO3') || defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
-use \TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Page\AssetCollector;
 


### PR DESCRIPTION
This constant has been removed in TYPO3 12.0: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96107-DeprecatedFunctionalityRemoved.html